### PR TITLE
Fix dashboard build so that it works on CentOS 7

### DIFF
--- a/bin/esg-dashboard
+++ b/bin/esg-dashboard
@@ -360,7 +360,7 @@ setup_geoip() {
         
         pushd ${geoip_dist_dir} >& /dev/null
         ((force_install)) && (echo "Cleaning the source tree.. $(pwd) " && gmake clean && echo "[OK]" || echo "[FAIL]")
-        automake
+        autoreconf --install
         echo "./configure --prefix=${geoip_install_dir}"
         if ./configure --prefix=${geoip_install_dir} \
             && make \
@@ -480,7 +480,7 @@ setup_dashboard_provider() {
 
     pushd ${esgf_dashboard_ip_dist_dir}
     ((force_install)) && (echo "Cleaning the source tree.. $(pwd) " && make clean && echo "[OK]" || echo "(Hmmm... not respecting \"make clean\" - eh, no worries)")
-    automake
+    autoreconf --install
     echo "./configure --prefix=${esgf_dashboard_ip_install_dir}"
     if ./configure --prefix=${esgf_dashboard_ip_install_dir} --with-postgres-path=${postgress_install_dir} --with-geoip-prefix-path=${geoip_install_dir} \
 	&& make \

--- a/src/c/esgf-dashboard-ip/src/ftpget.c
+++ b/src/c/esgf-dashboard-ip/src/ftpget.c
@@ -7,7 +7,6 @@
 
 #include <stdio.h>
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 #include "ftpget.h"
 #include "error.h"


### PR DESCRIPTION
Note that "curl/types.h" doesn't exist on C7 and is an empty header
on C6.